### PR TITLE
Match multiline function declarations to devbook

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -479,11 +479,10 @@ func reticulateSplines(spline: [Double]) -> Bool {
 For functions with long signatures, put each parameter on a new line and add an extra indent on subsequent lines:
 
 ```swift
-func reticulateSplines(
-  spline: [Double], 
-  adjustmentFactor: Double,
-  translateConstant: Int, comment: String
-) -> Bool {
+func reticulateSplines(spline: [Double], 
+                       adjustmentFactor: Double,
+                       translateConstant: Int, 
+                       comment: String) -> Bool {
   // reticulate code goes here
 }
 ```


### PR DESCRIPTION
since https://github.com/vinted/devbook/pull/201 was agreed in 2016 let's discuss if this makes sense in 2019 @vinted/ios 